### PR TITLE
Changes for LINX update/LabVIEW 2019 SP1 deb image.

### DIFF
--- a/make_deb.sh
+++ b/make_deb.sh
@@ -6,15 +6,27 @@ if [ $# -ne 1 ]; then
   echo "Usage: $0 IMAGE_TAR_FILE"
   exit 1
 fi
+DFLT_IMGFILE="build/tmp/deploy/images/generic-armv7a/core-image-minimal-chroot-generic-armv7a.tar.gz"
+IMAGE_TAR="$1"
+if [ -d "$IMAGE_TAR" -a -f "$IMAGE_TAR/$DFLT_IMGFILE" ]; then
+	IMAGE_TAR="$IMAGE_TAR/$DFLT_IMGFILE"
+fi
+if [ ! -f "$IMAGE_TAR" ]; then
+	echo "$0: $IMAGE_TAR does not exist"
+	exit 1
+fi
 
-PKG_NAME=lvrt-schroot
-PKG_VER=14.1
-PKG_REV=11
+PKG_NAME=lvrt19-schroot
+PKG_VER=19.0.1
+PKG_REV=3
 PKG_DIR=$PKG_NAME\_$PKG_VER-$PKG_REV
 REPO_DIR=debian
 
-SYSTEMD_SERVICE_DIR=$PKG_DIR/etc/systemd/system/multi-user.target.wants
+SYSTEMD_SERVICE_DIR=$PKG_DIR/etc/systemd/system
+SYSTEMD_SERVICE_MUT_DIR=$SYSTEMD_SERVICE_DIR/multi-user.target.wants
 CHROOT_DIR=$PKG_DIR/srv/chroot/labview
+
+sudo rm -rf $PKG_DIR
 
 # Add schroot session creation script
 mkdir -p $PKG_DIR/usr/sbin
@@ -22,10 +34,17 @@ cp src/schroot-lv-start.sh $PKG_DIR/usr/sbin/.
 
 # Add systemd service file to start schroot
 mkdir -p $SYSTEMD_SERVICE_DIR
-cp src/labview.service $SYSTEMD_SERVICE_DIR/.
+mkdir -p $SYSTEMD_SERVICE_MUT_DIR
+cp src/labview.service $SYSTEMD_SERVICE_DIR/
+rm -f $SYSTEMD_SERVICE_MUT_DIR/labview.service
+ln -sf /etc/systemd/system/labview.service $SYSTEMD_SERVICE_MUT_DIR/labview.service
 
 # Add systemd service file to start emulated sys web server
-cp src/nisysserver.service $SYSTEMD_SERVICE_DIR/.
+cp src/nisysserver.service $SYSTEMD_SERVICE_DIR/
+rm -f $SYSTEMD_SERVICE_MUT_DIR/nisysserver.service
+ln -sf /etc/systemd/system/nisysserver.service $SYSTEMD_SERVICE_MUT_DIR/nisysserver.service
+
+cp src/linxioserver.service $SYSTEMD_SERVICE_DIR/
 
 # Add NI Sys Web Server emulator script
 cp src/NISysServer.py $PKG_DIR/usr/sbin/.
@@ -47,10 +66,13 @@ sudo chown -R root:root $PKG_DIR/*
 
 # Create chroot dir
 mkdir -p $CHROOT_DIR
-if [[ $1 == *tar.bz2 ]]; then
-	tar xjf $1 -C $CHROOT_DIR
-elif [[ $1 == *tar.gz ]]; then
-	tar xzf $1 -C $CHROOT_DIR
+if [[ "$IMAGE_TAR" == *tar.bz2 ]]; then
+	tar xjf "$IMAGE_TAR" -C $CHROOT_DIR
+elif [[ "$IMAGE_TAR" == *tar.gz ]]; then
+	tar xzf "$IMAGE_TAR" -C $CHROOT_DIR
+else
+	echo "$0: Error: Can't extract file $IMAGE_TAR"
+	exit 1
 fi
 
 # Do a little customization to the chroot
@@ -59,19 +81,21 @@ rm -r $CHROOT_DIR/home/root
 
 # Create control file and maintainer scripts
 mkdir $PKG_DIR/DEBIAN
-cp src/control $PKG_DIR/DEBIAN/.
+sed 's/VERSION/'$PKG_VER-$PKG_REV'/' src/control > $PKG_DIR/DEBIAN/control
 cp src/post* $PKG_DIR/DEBIAN/.
 cp src/pre* $PKG_DIR/DEBIAN/.
 
 # Create the package
-dpkg-deb --build $PKG_DIR
+dpkg-deb -Zgzip --build $PKG_DIR
 
 # Create the repo
 mkdir -p $REPO_DIR/binary
 cp $PKG_DIR.deb $REPO_DIR/binary/.
 cd $REPO_DIR
-dpkg-scanpackages binary /dev/null > binary/Packages
+sudo dpkg-scanpackages binary /dev/null > binary/Packages
+sudo chown $USER binary/Packages
 cd binary
+rm -f Packages.gz
 gzip Packages
 
 #cleanup

--- a/make_deb.sh
+++ b/make_deb.sh
@@ -44,7 +44,8 @@ cp src/nisysserver.service $SYSTEMD_SERVICE_DIR/
 rm -f $SYSTEMD_SERVICE_MUT_DIR/nisysserver.service
 ln -sf /etc/systemd/system/nisysserver.service $SYSTEMD_SERVICE_MUT_DIR/nisysserver.service
 
-cp src/linxioserver.service $SYSTEMD_SERVICE_DIR/
+cp src/linxioserver-tcp.service $SYSTEMD_SERVICE_DIR/
+cp src/linxioserver-serial.service $SYSTEMD_SERVICE_DIR/
 
 # Add NI Sys Web Server emulator script
 cp src/NISysServer.py $PKG_DIR/usr/sbin/.

--- a/src/NISysServer.py
+++ b/src/NISysServer.py
@@ -71,14 +71,14 @@ class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 			s.send_header("Set-Cookie", "_appwebSessionId_=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT")
 			s.end_headers()
 			s.wfile.write("User admin logged out.")
-		elif ppath.path == 'deletetree':
+		elif ppath.path == '/deletetree':
 			# call to service locator to remove a service
 			# this happens when LV daemon shuts down
 			# since the daemon might not be running when the 
 			# response is sent, just close the connection
 			print "GET deletetree received"
 			s.wfile.close()
-		elif ppath.path == 'publish':
+		elif ppath.path == '/publish':
 			# call to service locator to add a service
 			# this happens when LV daemon starts
 			s.send_response(200)

--- a/src/control
+++ b/src/control
@@ -1,7 +1,9 @@
-Package: lvrt-schroot
-Version: 14.1-11
+Package: lvrt19-schroot
+Version: VERSION
 Section: base
 Priority: optional
+Replaces: lvrt-schroot (<< 19.0.1-6)
+Conflicts: lvrt-schroot (<< 19.0.1-6)
 Architecture: armhf
 Depends: schroot, python, avahi-daemon
 Maintainer: LabVIEWMakerHub Administrator <admin@labviewmakerhub.com>

--- a/src/labview.5
+++ b/src/labview.5
@@ -1,4 +1,4 @@
-.TH labview 5 "07 Dec 2015" "14.1" "labview man page"
+.TH labview 5 "07 Aug 2019" "19.0.1" "labview man page"
 .SH NAME
 labview \- run-time engine for LabVIEW Virtual Instruments
 .SH LICENSE

--- a/src/labview.service
+++ b/src/labview.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LabVIEW chroot run-time daemon
+Description=LabVIEW 2019 SP1 chroot run-time daemon
 After=network.target
 
 [Service]

--- a/src/linxioserver-serial.service
+++ b/src/linxioserver-serial.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Linx Serial IO Server
+Requires=labview.service
+After=labview.service
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/chroot /var/lib/schroot/mount/lv /usr/bin/linxioserver -serial 0
+

--- a/src/linxioserver-tcp.service
+++ b/src/linxioserver-tcp.service
@@ -1,11 +1,9 @@
 [Unit]
 Description=Linx TCP IO Server
+Requires=labview.service
 After=labview.service
 
 [Service]
 Type=simple
 ExecStart=/usr/sbin/chroot /var/lib/schroot/mount/lv /usr/bin/linxioserver -tcp 44300
-
-#[Install]
-#WantedBy=multi-user.target
 

--- a/src/linxioserver.service
+++ b/src/linxioserver.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Linx TCP IO Server
+After=labview.service
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/chroot /var/lib/schroot/mount/lv /usr/bin/linxioserver -tcp 44300
+
+#[Install]
+#WantedBy=multi-user.target
+

--- a/src/lvrt.5
+++ b/src/lvrt.5
@@ -1,4 +1,4 @@
-.TH lvrt 5 "07 Dec 2015" "14.1" "labview man page"
+.TH lvrt 5 "07 Aug 2019" "19.0.1" "labview man page"
 .SH NAME
 lvrt \- run-time engine for LabVIEW Virtual Instruments
 .SH LICENSE

--- a/src/postinst
+++ b/src/postinst
@@ -8,42 +8,60 @@ systemctl start labview.service
 # Check for the existence if liblinxdevice
 # and add a symlink to the appropriate version
 CHROOTPATH=/srv/chroot/labview
+
 RPI2LINX=liblinxdevice_rpi2.so
+RPI2LINXPATH=/usr/lib/$RPI2LINX
+
 BBLINX=liblinxdevice_bbb.so
 BBLINXPATH=/usr/lib/$BBLINX
+
+USRBINPATH=/usr/bin
 LINXPATH=$CHROOTPATH/usr/lib/liblinxdevice.so
 PREAMBLE="<?xml version=\"1.0\" standalone='no'?>"
 FMTSTR='<!DOCTYPE service-group SYSTEM "avahi-service.dtd">\n<service-group>\n  <name replace-wildcards="yes">%%h</name>\n  <service>\n    <type>_ni._tcp</type>\n    <port>3580</port>\n    <txt-record>ProdName=%s</txt-record>\n    <txt-record>DevClass=LINX</txt-record>\n  </service>\n</service-group>\n'
 AVAHISVC=/etc/avahi/services/lvrt.service
 
 # hard link resolv.conf from host system to chroot
+rm -f $CHROOTPATH/etc/resolv.conf
 ln /etc/resolv.conf $CHROOTPATH/etc/resolv.conf
 
 # symlink update-ca-certificates to make ca-certificates pkg happy
-ln -s /usr/sbin/update-ca-certificates $CHROOTPATH/usr/bin/update-ca-certificates
+ln -sf /usr/sbin/update-ca-certificates $CHROOTPATH/usr/bin/update-ca-certificates
 
-if [ -e $CHROOTPATH$BBLINXPATH ]; then
+if [ -e $CHROOTPATH$RPI2LINXPATH ]; then
 	# Raspberry Pi 2
-	cat /proc/cpuinfo | grep BCM2709 > /dev/null && :
+	# cat /proc/cpuinfo | grep BCM2709 > /dev/null && :
+	test -e /sys/firmware/devicetree/base/model && cat /sys/firmware/devicetree/base/model | 
+	    sed -e 's, Model.*,\n,' -e 's, Rev.*,\n,' | grep 'Raspberry Pi [234]' > /dev/null && :
 	if [ $? -eq 0 ]; then
 		# Create symlink to correct liblinxdevice.so
-		ln -s $RPI2LINX $LINXPATH
+		ln -sf $RPI2LINX $LINXPATH
 		chmod 0755 $LINXPATH
 		# Add Avahi service for LV daemon
 		echo $PREAMBLE > $AVAHISVC
 		printf "$FMTSTR" "RPi2" >> $AVAHISVC
+
+		test -x $CHROOTPATH/$USRBINPATH/linxtcpserver-rpi && ln -sf linxtcpserver-rpi $CHROOTPATH/$USRBINPATH/linxtcpserver
+		test -x $CHROOTPATH/$USRBINPATH/linxserialserver-rpi && ln -sf linxserialserver-rpi $CHROOTPATH/$USRBINPATH/linxserialserver
+		test -x $CHROOTPATH/$USRBINPATH/linxioserver-rpi && ln -sf linxioserver-rpi $CHROOTPATH/$USRBINPATH/linxioserver
 		exit 0
 	fi
+fi
 
+if [ -e $CHROOTPATH$BBLINXPATH ]; then
 	# BeagleBone Black
 	cat /proc/cpuinfo | grep AM33XX > /dev/null && :
 	if [ $? -eq 0 ]; then
 		# Create symlink to correct liblinxdevice.so
-		ln -s $BBLINX $LINXPATH
+		ln -sf $BBLINX $LINXPATH
 		chmod 0755 $LINXPATH
 		# Add Avahi service for LV daemon
 		echo $PREAMBLE > $AVAHISVC
 		printf "$FMTSTR" "BBB" >> $AVAHISVC
+
+		test -x $CHROOTPATH/$USRBINPATH/linxtcpserver-bb && ln -sf linxtcpserver-bb $CHROOTPATH/$USRBINPATH/linxtcpserver
+		test -x $CHROOTPATH/$USRBINPATH/linxserialserver-bb && ln -sf linxserialserver-bb $CHROOTPATH/$USRBINPATH/linxserialserver
+		test -x $CHROOTPATH/$USRBINPATH/linxioserver-bb && ln -sf linxioserver-bb $CHROOTPATH/$USRBINPATH/linxioserver
 		exit 0
 	fi
 fi

--- a/src/postrm
+++ b/src/postrm
@@ -7,22 +7,19 @@ systemctl daemon-reload
 CHROOTPATH=/srv/chroot/labview
 
 RESOLVPATH=$CHROOTPATH/etc/resolv.conf
-if [ -e $RESOLVPATH ]; then
-	rm $RESOLVPATH
-fi
+rm -f $RESOLVPATH
 
 UPDATECERTPATH=$CHROOTPATH/usr/bin/update-ca-certificates
-if [ -e $UPDATECERTPATH ]; then
-	rm $UPDATECERTPATH
-fi
+rm -f $UPDATECERTPATH
 
 LINXPATH=$CHROOTPATH/usr/lib/liblinxdevice.so
-if [ -e $LINXPATH ]; then
-	rm $LINXPATH
-fi
+rm -f $LINXPATH
+
+rm -f $CHROOTPATH/usr/bin/linxserialserver
+rm -f $CHROOTPATH/usr/bin/linxtcpserver
+rm -f $CHROOTPATH/usr/bin/linxioserver
 
 # remove LV avahi service
 AVAHISVC=/etc/avahi/services/lvrt.service
-if [ -e $AVAHISVC ]; then
-	rm $AVAHISVC
-fi
+rm -f $AVAHISVC
+exit 0

--- a/src/preinst
+++ b/src/preinst
@@ -12,10 +12,12 @@ fi
 # if so, then stop them
 foo=`systemctl | grep labview`
 if [ $? -eq 0 ]; then
-	systemctl stop labview.service
+	systemctl is-active --quiet labview.service && systemctl stop labview.service
 fi
 
 foo=`systemctl | grep nisysserver`
 if [ $? -eq 0 ]; then
-	systemctl stop nisysserver.service
+	systemctl is-active --quiet nisysserver.service && systemctl stop nisysserver.service
 fi
+
+exit 0

--- a/src/prerm
+++ b/src/prerm
@@ -3,5 +3,7 @@
 
 systemctl is-active --quiet labview.service && systemctl stop labview.service
 systemctl is-active --quiet nisysserver.service && systemctl stop nisysserver.service
+systemctl is-active --quiet linxioserver-tcp.service && systemctl stop lixioserver-tcp.service
+systemctl is-active --quiet linxioserver-serial.service && systemctl stop linxioserver-serial.service
 
 exit 0

--- a/src/prerm
+++ b/src/prerm
@@ -1,5 +1,7 @@
 #!/bin/sh
 # postinst script for lvrt-schroot
 
-systemctl stop labview.service
-systemctl stop nisysserver.service
+systemctl is-active --quiet labview.service && systemctl stop labview.service
+systemctl is-active --quiet nisysserver.service && systemctl stop nisysserver.service
+
+exit 0

--- a/src/schroot-lv-start.sh
+++ b/src/schroot-lv-start.sh
@@ -4,7 +4,7 @@ LV_SESSION_FILE=/var/lib/schroot/session/lv
 
 # check to make sure that the last schroot session shut down correctly
 if [ -e $LV_SESSION_FILE ]; then
-	rm $LV_SESSION_FILE
+	rm -f $LV_SESSION_FILE
 fi
 
 # start the session


### PR DESCRIPTION
- Auto-update version number in control file based on vars at top of make_deb.sh.
- Allow specifying just top-level yocto/poky dir, use default location of
  arm image .tar.gz file below that.
- Remove old package-dir before building deb to avoid stale files
- Create needed symlinks to services in /etc/systemd/system/multi-user.target.wants
- Add service for Linx I/O standalone server (for TCP), not started by default
- Use -Zgzip arg to dpkg-deb, since default is now bzip2 but that causes incompatiblity
  with older Debian images, which we still support.
- Fix bug in NISysServer, /deletetree and /publish commands were not
  working because of leading '/' mismatch
- Improve detection of RPi or BBB target to make liblinxdevice.so
  symlink; use /sys/firmware/devicetree/base/model instead of /proc/cpuinfo
- Cleanup preinst/postinst scripts to avoid noise reinstalling/uninstalling