### PR TITLE
Python3 upgrade

### DIFF
--- a/src/control
+++ b/src/control
@@ -6,7 +6,7 @@ Provides: lvrt-schroot
 Replaces: lvrt-schroot, lvrt19-schroot, lvrt20-schroot, lvrt21-schroot, lvrt22-schroot
 Conflicts: lvrt-schroot, lvrt19-schroot, lvrt20-schroot, lvrt21-schroot, lvrt22-schroot
 Architecture: armhf
-Depends: schroot, python, avahi-daemon, debhelper
+Depends: schroot, python3, avahi-daemon, debhelper
 Maintainer: LabVIEWMakerHub Administrator <admin@labviewmakerhub.com>
 Description: LabVIEW run-time schroot
  A schroot environment to allow the softfp LabVIEW run-time to run on a hardfp


### PR DESCRIPTION
This PR resolves issue #14.

Basically, port from python2 to python3.  In the bookworm release, raspbian removed python2 from the feeds.  This broke LabVIEW installation.

I tested on the bookworm release with LV 23Q1.  I did not have a RPi5 available to test on but I don't think the issue actually requires a RPi5.