### PR TITLE
Update version numbers and copyrights for 2024

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2021 National Instruments
+Copyright (c) 2016-2024 National Instruments
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/make_deb.sh
+++ b/make_deb.sh
@@ -16,8 +16,8 @@ if [ ! -f "$IMAGE_TAR" ]; then
 	exit 1
 fi
 
-PKG_NAME=lvrt23-schroot
-PKG_VER=23.1.0
+PKG_NAME=lvrt24-schroot
+PKG_VER=24.1.0
 PKG_REV=1
 PKG_DIR=$PKG_NAME\_$PKG_VER-$PKG_REV
 REPO_DIR=debian

--- a/make_deb.sh
+++ b/make_deb.sh
@@ -18,7 +18,7 @@ fi
 
 PKG_NAME=lvrt24-schroot
 PKG_VER=24.1.0
-PKG_REV=1
+PKG_REV=2
 PKG_DIR=$PKG_NAME\_$PKG_VER-$PKG_REV
 REPO_DIR=debian
 

--- a/make_lvrt_image.sh
+++ b/make_lvrt_image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-LVRT_PKG=lvrt23-schroot
+LVRT_PKG=lvrt24-schroot
 TMP_DIR=./tmp
 MNT_DIR=./mnt
 

--- a/src/control
+++ b/src/control
@@ -3,10 +3,10 @@ Version: VERSION
 Section: base
 Priority: optional
 Provides: lvrt-schroot
-Replaces: lvrt-schroot, lvrt19-schroot, lvrt20-schroot, lvrt21-schroot, lvrt22-schroot
-Conflicts: lvrt-schroot, lvrt19-schroot, lvrt20-schroot, lvrt21-schroot, lvrt22-schroot
+Replaces: lvrt-schroot, lvrt19-schroot, lvrt20-schroot, lvrt21-schroot, lvrt22-schroot, lvrt23-schroot
+Conflicts: lvrt-schroot, lvrt19-schroot, lvrt20-schroot, lvrt21-schroot, lvrt22-schroot, lvrt23-schroot
 Architecture: armhf
-Depends: schroot, python3, avahi-daemon, debhelper
+Depends: schroot, python3, avahi-daemon
 Maintainer: LabVIEWMakerHub Administrator <admin@labviewmakerhub.com>
 Description: LabVIEW run-time schroot
  A schroot environment to allow the softfp LabVIEW run-time to run on a hardfp

--- a/src/labview.service
+++ b/src/labview.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LabVIEW 2023 Q1 chroot run-time daemon
+Description=LabVIEW 2024 Q1 chroot run-time daemon
 After=network.target
 
 [Service]


### PR DESCRIPTION
Trivial 2023->2024 and copyright year edits.

Remove obsolete debhelper dep.