### PR TITLE
Add support for arm64

### DIFF
--- a/src/control
+++ b/src/control
@@ -1,11 +1,11 @@
-Package: lvrt-schroot
+Package: NAME
 Version: VERSION
 Section: base
 Priority: optional
-Provides: lvrt-schroot
-Replaces: lvrt-schroot, lvrt19-schroot, lvrt20-schroot, lvrt21-schroot, lvrt22-schroot, lvrt23-schroot
-Conflicts: lvrt-schroot, lvrt19-schroot, lvrt20-schroot, lvrt21-schroot, lvrt22-schroot, lvrt23-schroot
-Architecture: armhf
+Provides: NAME
+Replaces: NAME, lvrt19-schroot, lvrt20-schroot, lvrt21-schroot, lvrt22-schroot, lvrt23-schroot, lvrt24-schroot
+Conflicts: NAME, lvrt19-schroot, lvrt20-schroot, lvrt21-schroot, lvrt22-schroot, lvrt23-schroot, lvrt24-schroot
+Architecture: ARCH
 Depends: schroot, python3, avahi-daemon
 Maintainer: LabVIEWMakerHub Administrator <admin@labviewmakerhub.com>
 Description: LabVIEW run-time schroot

--- a/src/labview.service
+++ b/src/labview.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=LabVIEW 2024 Q1 chroot run-time daemon
+Description=LabVIEW 2025 Q1 chroot run-time daemon
 After=network.target
 
 [Service]


### PR DESCRIPTION
This commit should allow for creating both 32-bit and 64-bit ARM packages.  This will allow the lvrt-schroot package to install on 64-bit Raspbian.

Changes:
* Update version numbers for 25.1 release
* Add Architecture template to the control file
* Rename package name template to make it clear it's a template variable.
* Create function for package file creation.  Invoke it once for each supported architecture.
* Use multiversion option with dpkg-scanpackages to allow multiple architecture packages in the same debian repo.